### PR TITLE
Link to new public profile edition

### DIFF
--- a/backend/services/app.service.js
+++ b/backend/services/app.service.js
@@ -35,10 +35,7 @@ module.exports = {
         'apods:ReadInbox',
         'apods:ReadOutbox',
         'apods:PostOutbox',
-        'apods:QuerySparqlEndpoint',
-        'apods:CreateWacGroup',
-        'apods:CreateCollection',
-        'apods:UpdateWebId'
+        'apods:QuerySparqlEndpoint'
       ],
       optional: []
     },

--- a/frontend/src/common/buttons/EditProfileButton.jsx
+++ b/frontend/src/common/buttons/EditProfileButton.jsx
@@ -1,0 +1,51 @@
+import { useState, useRef } from 'react';
+import { Button, Paper, Popper, MenuItem, MenuList, ClickAwayListener } from '@mui/material';
+import { useGetIdentity, useTranslate } from 'react-admin';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import useOpenExternalApp from '../../hooks/useOpenExternalApp';
+
+const EditProfileButton = ({ ...props }) => {
+  const [open, setOpen] = useState(false);
+  const anchorRef = useRef(null);
+  const translate = useTranslate();
+  const openExternalApp = useOpenExternalApp();
+  const { data: identity } = useGetIdentity();
+
+  return (
+    <>
+      <Button
+        variant="contained"
+        endIcon={<ArrowDropDownIcon />}
+        onClick={() => setOpen(prevOpen => !prevOpen)}
+        ref={anchorRef}
+        {...props}
+      >
+        {translate('app.action.edit_profile')}
+      </Button>
+      <Popper sx={{ zIndex: 1 }} open={open} anchorEl={anchorRef.current} placement="bottom">
+        <Paper>
+          <ClickAwayListener onClickAway={() => setOpen(false)}>
+            <MenuList id="split-button-menu" autoFocusItem>
+              <MenuItem
+                onClick={() => {
+                  window.location.href = openExternalApp('as:Profile', identity?.profileData?.id, 'edit');
+                }}
+              >
+                {translate('app.action.edit_private_profile')}
+              </MenuItem>
+              <MenuItem
+                onClick={() => {
+                  window.location.href = openExternalApp('as:Actor', identity?.id, 'edit');
+                }}
+              >
+                {translate('app.action.edit_public_profile')}
+              </MenuItem>
+            </MenuList>
+          </ClickAwayListener>
+        </Paper>
+      </Popper>
+    </>
+  );
+};
+
+export default EditProfileButton;

--- a/frontend/src/common/buttons/EditProfileButton.jsx
+++ b/frontend/src/common/buttons/EditProfileButton.jsx
@@ -35,7 +35,7 @@ const EditProfileButton = ({ ...props }) => {
               </MenuItem>
               <MenuItem
                 onClick={() => {
-                  window.location.href = openExternalApp('as:Actor', identity?.id, 'edit');
+                  window.location.href = openExternalApp('as:Person', identity?.id, 'edit');
                 }}
               >
                 {translate('app.action.edit_public_profile')}

--- a/frontend/src/common/cards/ProfileCard.jsx
+++ b/frontend/src/common/cards/ProfileCard.jsx
@@ -1,69 +1,56 @@
-import { Box, Card, Typography, Avatar, Button, Skeleton } from "@mui/material";
-import makeStyles from "@mui/styles/makeStyles";
-import { useCreatePath, useGetIdentity, useTranslate } from "react-admin";
-import { Link } from "react-router-dom";
-import useActorContext from "../../hooks/useActorContext";
-import FollowButton from "../buttons/FollowButton";
-import useOpenExternalApp from "../../hooks/useOpenExternalApp";
+import { Box, Card, Typography, Avatar, Skeleton } from '@mui/material';
+import makeStyles from '@mui/styles/makeStyles';
+import useActorContext from '../../hooks/useActorContext';
+import FollowButton from '../buttons/FollowButton';
+import EditProfileButton from '../buttons/EditProfileButton';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(theme => ({
   title: {
-    backgroundRepeat: "no-repeat",
-    backgroundSize: "cover",
+    backgroundRepeat: 'no-repeat',
+    backgroundSize: 'cover',
     backgroundImage: `radial-gradient(circle at 50% 14em, ${theme.palette.primary.light} 0%, ${theme.palette.primary.main} 100%)`,
     color: theme.palette.primary.contrastText,
     height: 85,
-    position: "relative",
+    position: 'relative'
   },
   avatarWrapper: {
-    position: "absolute",
+    position: 'absolute',
     margin: 10,
     top: 0,
     left: 0,
     right: 0,
-    textAlign: "center",
+    textAlign: 'center'
   },
   block: {
-    backgroundColor: "white",
+    backgroundColor: 'white',
     paddingTop: 80,
-    paddingBottom: 20,
+    paddingBottom: 20
   },
   button: {
-    backgroundColor: "white",
-    textAlign: "center",
-    "& a": {
-      textDecoration: "none",
-    },
+    backgroundColor: 'white',
+    textAlign: 'center',
+    '& a': {
+      textDecoration: 'none'
+    }
   },
   status: {
     marginTop: 8,
-    color: theme.palette.primary.main,
-  },
+    color: theme.palette.primary.main
+  }
 }));
 
 const ProfileCard = () => {
   const classes = useStyles();
-  const { data: identity } = useGetIdentity();
   const actor = useActorContext();
-  const translate = useTranslate();
-  const openExternalApp = useOpenExternalApp();
 
   return (
     <Card>
       <Box className={classes.title}>
-        <Box
-          display="flex"
-          justifyContent="center"
-          className={classes.avatarWrapper}
-        >
+        <Box display="flex" justifyContent="center" className={classes.avatarWrapper}>
           {actor.isLoading ? (
             <Skeleton variant="circular" width={150} height={150} />
           ) : (
-            <Avatar
-              src={actor?.image}
-              alt={actor?.name}
-              sx={{ width: 150, height: 150, bgcolor: "grey" }}
-            />
+            <Avatar src={actor?.image} alt={actor?.name} sx={{ width: 150, height: 150, bgcolor: 'grey' }} />
           )}
         </Box>
       </Box>
@@ -78,24 +65,19 @@ const ProfileCard = () => {
         <Typography
           align="center"
           sx={{
-            textOverflow: "ellipsis",
-            overflow: "hidden",
-            whiteSpace: "nowrap",
+            textOverflow: 'ellipsis',
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
             pl: 3,
-            pr: 3,
+            pr: 3
           }}
         >
           {actor?.username}
         </Typography>
       </Box>
-
       <Box className={classes.button} pb={3} pr={3} pl={3}>
         {actor.isLoggedUser ? (
-          <a href={openExternalApp("as:Profile", identity?.profileData?.id)}>
-            <Button variant="contained" color="secondary" type="submit">
-              {translate("app.action.edit_profile")}
-            </Button>
-          </a>
+          <EditProfileButton color="secondary" />
         ) : (
           <FollowButton color="secondary" actorUri={actor?.uri} />
         )}

--- a/frontend/src/config/messages/en.js
+++ b/frontend/src/config/messages/en.js
@@ -5,6 +5,8 @@ export default {
     description: 'A Mastodon-compatible app that saves all data in your Pod',
     action: {
       edit_profile: 'Edit profile',
+      edit_public_profile: 'Edit public profile',
+      edit_private_profile: 'Edit private profile',
       follow: 'Follow',
       unfollow: 'Unfollow',
       send: 'Send',
@@ -44,7 +46,7 @@ export default {
       post_like_removed: 'The post has been unstarred',
       actor_followed: 'You are now following this actor',
       actor_unfollowed: 'You are not following this actor anymore',
-      image_upload_error: 'Uploading picture failed',
+      image_upload_error: 'Uploading picture failed'
     },
     validation: {}
   }

--- a/frontend/src/config/messages/fr.js
+++ b/frontend/src/config/messages/fr.js
@@ -4,7 +4,9 @@ export default {
   app: {
     description: 'Une appli compatible Mastodon qui enregistre tout dans votre Pod',
     action: {
-      edit_profile: 'Editer le profile',
+      edit_profile: 'Éditer mon profil',
+      edit_public_profile: 'Éditer le profil public',
+      edit_private_profile: 'Éditer le profil privé',
       follow: 'Suivre',
       unfollow: 'Ne plus suivre',
       send: 'Envoyer',
@@ -44,7 +46,7 @@ export default {
       post_like_removed: 'Le like du message a été enlevé',
       actor_followed: 'Vous suivez maintenant cet acteur',
       actor_unfollowed: 'Vous ne suivez plus cet acteur',
-      image_upload_error: 'Echec de l\'upload de l\'image',
+      image_upload_error: "Échec de l'upload de l'image"
     },
     validation: {}
   }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig(({ mode }) => {
     },
     server: {
       host: true,
+      open: true,
       port: parseInt(env.VITE_PORT)
     },
     preview: {


### PR DESCRIPTION
Closes #3

Finally we will not allow to edit public profile from the Mastopod app, because this would force the app to ask for the `UpdateWebId` special right. The best practice is to give apps the least amount of privileges, to reduce risks for users. 

So we changed the "Edit profile" button to open a small menu which allow to select between "Edit public profile" and "Edit private profile", and it redirects to the [new pages on the Pod provider frontend](https://github.com/activitypods/activitypods/pull/354)